### PR TITLE
More xdem coreg support + reference point selection

### DIFF
--- a/scripts/coregister_arcticdem.py
+++ b/scripts/coregister_arcticdem.py
@@ -30,7 +30,7 @@ def main():
         "--coreg_steps",
         type=str,
         nargs="+",
-        choices=["VerticalShift", "ICP", "NuthKaab", "AffineCoreg", "DhMinimize"],
+        choices=["VerticalShift", "ICP", "NuthKaab", "AffineCoreg", "DhMinimize", "Deramp"],
         default=None,
         help="Coregistration steps (default: VerticalShift ICP NuthKaab)",
     )

--- a/scripts/fetch_and_coregister.py
+++ b/scripts/fetch_and_coregister.py
@@ -41,7 +41,7 @@ def main():
 
     parser.add_argument("--date_range", type=str, nargs=2, metavar=("START_DATE", "END_DATE"))
 
-    parser.add_argument("--min_valid_fraction", type=float, default=0.0)
+    parser.add_argument("--min_valid_fraction", type=float, default=0.5)
 
     parser.add_argument("--intersection_threshold", type=float, default=0.8)
 


### PR DESCRIPTION
## Summary
Improves DEM coregistration robustness through automatic reference DEM selection and NMAD-based stable ground filtering, with expanded xdem coregistration method support.

## Changes
- [x] Add NMAD-based reference DEM selection (lowest median NMAD to all other DEMs)
- [x] Add NMAD-based inlier mask for stable ground detection
  - [x] Fallback to slope-based mask when insufficient valid pixels
  - [ ] Make inlier mask more robust (multiple dem stack comp rather than last minus first)
- [ ] Option to remove DEMs from coreg stack with statistical systematic biases 
- [x] Add support for xdem `Deramp` coregistration method
- [ ] Add support for xdem `CPD` coregistration method
- [ ] Add support for xdem `LZD` coregistration method
- [ ] Add ICESat-2 GCP support #2
  - [ ] Test xdem `AffineCoreg` with GCPs
- [ ] Update/add documentation
- [ ] Add unit tests for new functionality